### PR TITLE
UPDATE: Phylip to tools manifest

### DIFF
--- a/tools/manifests/init.pp
+++ b/tools/manifests/init.pp
@@ -10,6 +10,7 @@ class tools {
       "tig",
       "clustalo",
       "ncbi-blast+",
+      "phylip",
     ],
     "CentOS" => [
       "expect",


### PR DESCRIPTION
For some reason phylip was not puppetized yet.
NOTE: For Fedora/CentOS it needs the RPM fusion repos.
So, phylip not yet included for RedHat family OS's.
See:
https://fedora.pkgs.org/32/rpm-sphere-x86_64/phylip-3.695-7.1.x86_64.rpm.html